### PR TITLE
Fix broken link

### DIFF
--- a/source/includes/_contributing.md
+++ b/source/includes/_contributing.md
@@ -2,15 +2,15 @@
 
 Want to hack on MARKET Protocol? Awesome!
 
-MARKET Protocol is an Open Source project and we welcome contributions of all sorts. 
+MARKET Protocol is an Open Source project and we welcome contributions of all sorts.
 There are many ways to help, from reporting issues, contributing code, and helping us improve our community.
 
 There are three main repositories that are considered as core components of the MARKET Protocol:
 
-- [MARKETProtocol](https://github.com/MARKETProtocol/MARKETProtocol) - the core protocol of solidity smart contracts 
+- [MARKETProtocol](https://github.com/MARKETProtocol/MARKETProtocol) - the core protocol of solidity smart contracts
 - [MARKET.js](https://github.com/MARKETProtocol/MARKET.js) - library of tools to interact with the protocol
-- [dApp](https://github.com/MARKETProtocol/dApp) - React based dApp for contract creation, exploration, and simulated trading. 
- 
+- [dApp](https://github.com/MARKETProtocol/dApp) - React based dApp for contract creation, exploration, and simulated trading.
+
 
 Additionally, these repositories have some very useful information for developers and community members
 
@@ -20,18 +20,18 @@ Additionally, these repositories have some very useful information for developer
 
 ## Dive Right In
 
-If you're ready to start helping us to build the decentralized future right now and you just need an issue to focus on, 
+If you're ready to start helping us to build the decentralized future right now and you just need an issue to focus on,
 check out [this list of open issues](https://github.com/orgs/MARKETProtocol/projects/1?card_filter_query=label%3A%22help+wanted%22+no%3Aassignee+is%3Aopen).
 
 Read our [development process](#development-process) and [community guidelines](#community-guidelines) first and have fun!
 
 ## Development Process
 
-We follow the [GitFlow](http://nvie.com/posts/a-successful-git-branching-model/) branching model for development. 
+We follow the [GitFlow](http://nvie.com/posts/a-successful-git-branching-model/) branching model for development.
 The latest merged code generally lives in the `develop` branch of each repository. Your development flow should look like:
 
 1. Find an interesting issue and communicate! Please let the #engineering Discord channel know what you want to work on
-1. Add a comment to the issue so we don't have multiple contributors unintentionally working on the same task. 
+1. Add a comment to the issue so we don't have multiple contributors unintentionally working on the same task.
 1. Please include your intended solution and a time frame for completion in the issue.
 1. Start with the `develop` branch and create a new feature branch
 1. Follow the appropriate [coding style](#coding-style) and write some awesome code
@@ -40,9 +40,9 @@ The latest merged code generally lives in the `develop` branch of each repositor
 
 
 ## Gitcoin and Bounties
- 
+
 We are very proud users of [Gitcoin](https://gitcoin.co/).  It allows us an easy way to reward our community members
-for their hard work contributing to MARKET Protocol.  Additionally, it allows us to gain traction on issues that are a 
+for their hard work contributing to MARKET Protocol.  Additionally, it allows us to gain traction on issues that are a
 priority for us to address.  We won't always stake every issue, but if you need a bounty to encourage your participation
 on an issue, and there isn't one yet, please reach out on [discord](https://www.marketprotocol.io/discord).
 
@@ -52,13 +52,13 @@ There are a few guidelines when using Gitcoin that are worth mentioning
 1. Please make sure to comment in the issue immediately after starting work so we know your plans for implementation and a timeline.
 1. We politely ask that users only have open work on a single bounty at a time, if you have an open bounty that has a PR submitted and would like to tackle another issue, please ask in [discord](https://www.marketprotocol.io/discord) before proceeding
 1. We will do our best to scope out the issue, but please anticipate some revision requested after you have submitted a PR, we are happy to tip you if these end up well beyond the initial scope
-1. Once you have create a PR, please `submit work` on Gitcoin so we are able to pay you out once we have accepted the work 
+1. Once you have create a PR, please `submit work` on Gitcoin so we are able to pay you out once we have accepted the work
 
 
 ## Coding Style
 
-We use a variety of programming languages in our repositories. When contributing, please follow existing coding conventions 
-and refer to the CONTRIBUTING.md file in the repository, if one exists. 
+We use a variety of programming languages in our repositories. When contributing, please follow existing coding conventions
+and refer to the CONTRIBUTING.md file in the repository, if one exists.
 
 [comment]: TODO: update style
 For JavaScript, we use [NPM's style](https://docs.npmjs.com/misc/coding-style), which is automatically enforced via [prettier](https://prettier.io/).
@@ -66,29 +66,29 @@ For JavaScript, we use [NPM's style](https://docs.npmjs.com/misc/coding-style), 
 
 ## Community Guidelines
 
-We want to keep the MARKET Protocol community awesome, growing and collaborative. 
+We want to keep the MARKET Protocol community awesome, growing and collaborative.
 We need your help to keep it that way. To help with this we've come up with some general guidelines for the community as a whole:
 
-- Be nice: Be courteous, respectful and polite to fellow community members: no regional, racial, gender, or other abuse 
+- Be nice: Be courteous, respectful and polite to fellow community members: no regional, racial, gender, or other abuse
 will be tolerated. We like nice people way better than mean ones!
 
-- Encourage diversity and participation: Make everyone in our community feel welcome, regardless of their background 
+- Encourage diversity and participation: Make everyone in our community feel welcome, regardless of their background
 and the extent of their contributions, and do everything possible to encourage participation in our community.
 
-- Keep it legal: Basically, don't get anybody in trouble. Share only content that you own, do not share private 
+- Keep it legal: Basically, don't get anybody in trouble. Share only content that you own, do not share private
 or sensitive information, and don't break laws.
 
-- Stay on topic: Make sure that you are posting to the correct channel and avoid off-topic discussions. 
-Remember when you update an issue or respond to an email you are potentially sending to a large number of people. 
+- Stay on topic: Make sure that you are posting to the correct channel and avoid off-topic discussions.
+Remember when you update an issue or respond to an email you are potentially sending to a large number of people.
 Please consider this before you update. Also remember that nobody likes spam.
 
-Full code of conduct is posted available [here](https://github.com/MARKETProtocol/meta/blob/master/guidelines/CODE_OF_CONDUCT.md])
+Full code of conduct is posted available [here](https://github.com/MARKETProtocol/meta/blob/master/guidelines/CODE_OF_CONDUCT.md)
 
 ## Reporting Issues
 
 If you find bugs, mistakes or inconsistencies in the project's code or
 documents, please let us know by filing an issue at the appropriate issue
-tracker (we use multiple repositories). 
+tracker (we use multiple repositories).
 
 <aside class="notice">
 No issue is too small. Help us fix our tpyos!
@@ -99,12 +99,12 @@ No issue is too small. Help us fix our tpyos!
  - [MARKET.js](https://github.com/MARKETProtocol/MARKET.js/issues)
  - [dApp issues](https://github.com/MARKETProtocol/dApp/issues)
  - [main website issues](https://github.com/MARKETProtocol/website/issues)
-  
+
 
 ## Security Issues
 
-The MARKET Protocol and its implementations are still in early development, which means there may be problems with the 
-protocol or in our implementations. We take security vulnerabilities very seriously. If you discover a security issue, 
+The MARKET Protocol and its implementations are still in early development, which means there may be problems with the
+protocol or in our implementations. We take security vulnerabilities very seriously. If you discover a security issue,
 please bring it to our attention right away!
 
 If you find a vulnerability please send your report privately to [support@marketprotocol.io](mailto:support@marketprotocol.io) Please DO NOT file a public issue.
@@ -115,17 +115,17 @@ If the issue is a protocol weakness or something not yet deployed, feel free to 
 
 MARKET Protocol is just as much about community as it is about our technology.
 
-We need constant help in improving our documentation, building new tools to interface with our platform, 
+We need constant help in improving our documentation, building new tools to interface with our platform,
 spreading the word to new users, helping new users getting setup and much more.
 
-Please get in touch if you would like to help out. Our `general` channel on [Discord](#discord) is a great place to 
+Please get in touch if you would like to help out. Our `general` channel on [Discord](#discord) is a great place to
 share ideas and volunteer to help.
 
 ## Full Time Positions
 
-MARKET Protocol occasionally hires developers for part time or full time positions. 
+MARKET Protocol occasionally hires developers for part time or full time positions.
 
-We have a strong preference for hiring people who have already started contributing to the project. 
-If you want a full time position on our team, your best shot is to engage with our team and start contributing code. 
-It is very unlikely that we would offer you a full time position on our engineering 
+We have a strong preference for hiring people who have already started contributing to the project.
+If you want a full time position on our team, your best shot is to engage with our team and start contributing code.
+It is very unlikely that we would offer you a full time position on our engineering
 team unless you've had at least a few pull requests merged.

--- a/source/includes/_contributing.md
+++ b/source/includes/_contributing.md
@@ -82,7 +82,7 @@ or sensitive information, and don't break laws.
 Remember when you update an issue or respond to an email you are potentially sending to a large number of people.
 Please consider this before you update. Also remember that nobody likes spam.
 
-Full code of conduct is posted available [here](https://github.com/MARKETProtocol/meta/blob/master/guidelines/CODE_OF_CONDUCT.md)
+Full code of conduct is posted available [here](https://github.com/MARKETProtocol/meta/blob/master/guidelines/CODE_OF_CONDUCT.md).
 
 ## Reporting Issues
 


### PR DESCRIPTION
Fix broken link to CODE_OF_CONDUCT.md
from https://docs.marketprotocol.io/#community-guidelines 
"Full code of conduct is posted available [here]"