### PR TITLE
Generate robots.txt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,9 @@ source 'https://rubygems.org'
 gem 'middleman', '~>4.2.1'
 gem 'middleman-syntax', '~> 3.0.0'
 gem 'middleman-autoprefixer', '~> 2.7.0'
-gem "middleman-sprockets", "~> 4.1.0"
+gem 'middleman-sprockets', '~> 4.1.0'
 gem 'rouge', '~> 2.0.5'
 gem 'redcarpet', '~> 3.4.0'
 gem 'nokogiri', '~> 1.8.2'
-gem "middleman-livereload", "~> 3.4.3"
+gem 'middleman-livereload', '~> 3.4.3'
+gem 'middleman-robots'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.3.15)
+    middleman-robots (1.3.3)
+      middleman (>= 4.0)
     middleman-sprockets (4.1.0)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
@@ -128,6 +130,7 @@ DEPENDENCIES
   middleman (~> 4.2.1)
   middleman-autoprefixer (~> 2.7.0)
   middleman-livereload (~> 3.4.3)
+  middleman-robots
   middleman-sprockets (~> 4.1.0)
   middleman-syntax (~> 3.0.0)
   nokogiri (~> 1.8.2)

--- a/config.rb
+++ b/config.rb
@@ -40,6 +40,13 @@ end
 activate :relative_assets
 set :relative_links, true
 
+# Generate robots.txt
+activate :robots,
+  rules: [
+    { user_agent: '*', disallow: %w() }
+  ],
+  sitemap: 'https://marketprotocol.io/sitemap.xml'
+
 # Build Configuration
 configure :build do
   # If you're having trouble with Middleman hanging, commenting


### PR DESCRIPTION
Use `middleman-robots` to generate `robots.txt` linking to the sitemap on the website.

Blocked by https://github.com/MARKETProtocol/website/issues/61